### PR TITLE
setup-poetry: Add `use-cache` input and regression tests

### DIFF
--- a/.github/workflows/test_actions.yml
+++ b/.github/workflows/test_actions.yml
@@ -55,8 +55,8 @@ jobs:
           fi
         shell: bash
 
-  test_setup_poetry_caching:
-    name: Test setup-poetry caching
+  test_setup_poetry_cache_hit:
+    name: Test setup-poetry (cache hit)
     runs-on: ${{ matrix.os }}
     needs: test_setup_poetry
     strategy:
@@ -73,11 +73,43 @@ jobs:
       - name: Set up Poetry
         id: setup-poetry
         uses: ./setup-poetry
-      - name: Check that Poetry was loaded from the cache
+      - name: Expect cache hit 
         if: steps.setup-poetry.outputs.cache-hit != 'true'
+        run: echo "::error title=Test Failure::Expected cache hit."; exit 1
+        shell: bash
+      - name: Create project
+        run: poetry new test-project
+      - name: Check that the project was created
         run: |
-          echo "::error title=Test Failure::The cache was not hit."
-          exit 1
+          if [ ! -f test-project/pyproject.toml ]; then
+            echo "::error title=Test Failure::The project file does not exist."
+            exit 1
+          fi
+        shell: bash
+  
+  test_setup_poetry_no_cache:
+    name: Test setup-poetry (no cache)
+    runs-on: ${{ matrix.os }}
+    needs: test_setup_poetry
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Python
+        uses: ./setup-python
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up Poetry
+        id: setup-poetry
+        uses: ./setup-poetry
+        with:
+          use-cache: false
+      - name: Expect cache miss 
+        if: steps.setup-poetry.outputs.cache-hit == 'true'
+        run: echo "::error title=Test Failure::Expected cache miss."; exit 1
         shell: bash
       - name: Create project
         run: poetry new test-project
@@ -177,7 +209,14 @@ jobs:
   test_results:
     name: Test Results
     runs-on: ubuntu-latest
-    needs: [test_setup_python, test_setup_poetry, test_setup_poetry_caching, test_check_project_version, test_update_project_version]
+    needs: [
+      test_setup_python, 
+      test_setup_poetry, 
+      test_setup_poetry_cache_hit,
+      test_setup_poetry_no_cache,
+      test_check_project_version,
+      test_update_project_version
+    ]
     if: ${{ !cancelled() }}
     steps:
       - run: exit 0

--- a/.github/workflows/test_actions.yml
+++ b/.github/workflows/test_actions.yml
@@ -55,6 +55,40 @@ jobs:
           fi
         shell: bash
 
+  test_setup_poetry_caching:
+    name: Test setup-poetry caching
+    runs-on: ${{ matrix.os }}
+    needs: test_setup_poetry
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Python
+        uses: ./setup-python
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up Poetry
+        id: setup-poetry
+        uses: ./setup-poetry
+      - name: Check that Poetry was loaded from the cache
+        if: steps.setup-poetry.outputs.cache-hit != 'true'
+        run: |
+          echo "::error title=Test Failure::The cache was not hit."
+          exit 1
+        shell: bash
+      - name: Create project
+        run: poetry new test-project
+      - name: Check that the project was created
+        run: |
+          if [ ! -f test-project/pyproject.toml ]; then
+            echo "::error title=Test Failure::The project file does not exist."
+            exit 1
+          fi
+        shell: bash
+  
   test_check_project_version:
     name: Test check-project-version
     runs-on: ubuntu-latest
@@ -143,7 +177,7 @@ jobs:
   test_results:
     name: Test Results
     runs-on: ubuntu-latest
-    needs: [test_setup_python, test_setup_poetry, test_check_project_version, test_update_project_version]
+    needs: [test_setup_python, test_setup_poetry, test_setup_poetry_caching, test_check_project_version, test_update_project_version]
     if: ${{ !cancelled() }}
     steps:
       - run: exit 0

--- a/.github/workflows/test_actions.yml
+++ b/.github/workflows/test_actions.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           import sys
           version = sys.version_info[:2]
-          expected_version = tuple("${{ matrix.python-version }}".split("."))
+          expected_version = tuple(map(int, "${{ matrix.python-version }}".split(".")))
           if version != expected_version:
               print(f"::error title=Test Failure::The Python version does not match. Got {version}, expected {expected_version}.")
               sys.exit(1)

--- a/.github/workflows/test_actions.yml
+++ b/.github/workflows/test_actions.yml
@@ -28,6 +28,7 @@ jobs:
               print(f"::error title=Test Failure::The Python version does not match. Got {version}, expected {expected_version}.")
               sys.exit(1)
         shell: python
+
   test_setup_poetry:
     name: Test setup-poetry
     runs-on: ${{ matrix.os }}
@@ -53,6 +54,7 @@ jobs:
             exit 1
           fi
         shell: bash
+
   test_check_project_version:
     name: Test check-project-version
     runs-on: ubuntu-latest
@@ -86,6 +88,7 @@ jobs:
         run: |
           echo "::error title=Test Failure::The previous step did not fail as expected."
           exit 1
+
   test_update_project_version:
     name: Test update-project-version
     runs-on: ubuntu-latest
@@ -132,3 +135,15 @@ jobs:
         with:
           project-directory: test-project
           expected-version: 1.0.2.dev1
+
+  # This job is intended to combine the test results so we don't have to list
+  # each matrix combination in the required status check settings. There are a
+  # lot of corner cases that make this harder than it should be; see See
+  # https://github.com/orgs/community/discussions/26822 for more info.
+  test_results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    needs: [test_setup_python, test_setup_poetry, test_check_project_version, test_update_project_version]
+    if: ${{ !cancelled() }}
+    steps:
+      - run: exit 0

--- a/.github/workflows/test_actions.yml
+++ b/.github/workflows/test_actions.yml
@@ -5,6 +5,54 @@ on:
   workflow_dispatch:
 
 jobs:
+  test_setup_python:
+    name: Test setup-python
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Python
+        uses: ./setup-python
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Check Python version
+        run: |
+          import sys
+          version = sys.version_info[:2]
+          expected_version = tuple("${{ matrix.python-version }}".split("."))
+          if version != expected_version:
+              print(f"::error title=Test Failure::The Python version does not match. Got {version}, expected {expected_version}.")
+              sys.exit(1)
+        shell: python
+  test_setup_poetry:
+    name: Test setup-poetry
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Python
+        uses: ./setup-python
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up Poetry
+        uses: ./setup-poetry
+      - name: Create project
+        run: poetry new test-project
+      - name: Check that the project was created
+        run: |
+          if [ ! -f test-project/pyproject.toml ]; then
+            echo "::error title=Test Failure::The project file does not exist."
+            exit 1
+          fi
+        shell: bash
   test_check_project_version:
     name: Test check-project-version
     runs-on: ubuntu-latest

--- a/.github/workflows/test_actions.yml
+++ b/.github/workflows/test_actions.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Poetry
         id: setup-poetry
         uses: ./setup-poetry
-      - name: Expect cache hit 
+      - name: Error if cache miss
         if: steps.setup-poetry.outputs.cache-hit != 'true'
         run: echo "::error title=Test Failure::Expected cache hit."; exit 1
         shell: bash
@@ -107,7 +107,7 @@ jobs:
         uses: ./setup-poetry
         with:
           use-cache: false
-      - name: Expect cache miss 
+      - name: Error if cache hit
         if: steps.setup-poetry.outputs.cache-hit == 'true'
         run: echo "::error title=Test Failure::Expected cache miss."; exit 1
         shell: bash

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
     - [Usage](#usage-1)
     - [Inputs](#inputs-1)
       - [`poetry-version`](#poetry-version)
+      - [`use-cache`](#use-cache)
+    - [Outputs](#outputs-1)
+      - [`cache-hit`](#cache-hit)
   - [`ni/python-actions/check-project-version`](#nipython-actionscheck-project-version)
     - [Usage](#usage-2)
     - [Inputs](#inputs-2)
@@ -124,6 +127,17 @@ steps:
     poetry-version: 2.1.3
 - run: poetry install -v
 ```
+
+#### `use-cache`
+
+If you run into caching problems, you can disable caching by specifying `use-cache: false`.
+
+### Outputs
+
+#### `cache-hit`
+
+You can use `cache-hit` to check whether Poetry was loaded from cache. This is mainly intended for
+testing the action.
 
 ## `ni/python-actions/check-project-version`
 

--- a/setup-poetry/action.yml
+++ b/setup-poetry/action.yml
@@ -3,6 +3,17 @@ description: Install Poetry, add it to the PATH, and cache it to speed up workfl
 inputs:
   poetry-version:
     default: 1.8.2
+  use-cache:
+    description: >
+      A Boolean specifying whether to use the cache. Set this to false to work
+      around caching problems.
+    default: true
+outputs:
+  cache-hit:
+    description: >
+      A Boolean indicating whether Poetry was loaded from the cache. This is
+      mainly intended for testing the action.
+    value: ${{ steps.cache-poetry.outputs.cache-hit }}
 runs:
   using: composite
   steps:
@@ -38,6 +49,7 @@ runs:
         echo "poetry-home=$POETRY_HOME" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Cache poetry
+      if: ${{ inputs.use-cache == 'true' }}
       id: cache-poetry
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:


### PR DESCRIPTION
### What does this Pull Request accomplish?

`setup-poetry`:
- Add a `use-cache` input which can be used to disable caching.
- Add a `cache-hit` output for testing.

tests:
- Add a test job for `setup-python` that uses a matrix to run on all supported Python versions on Windows and Linux.
- Add two test jobs for `setup-poetry` that use a matrix. The second test job verifies that Poetry works after being loaded from the cache.

### Why should this Pull Request be merged?

Work around #7 if it reoccurs.

Add more test coverage.

### What testing has been done?

PR build