### PR TITLE
update-project-version: Add `token` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,9 @@ desired release version before creating a release in GitHub.
 
 #### `token`
 
-The default GITHUB_TOKEN cannot trigger PR workflows. You can work around this by using `token` to
-specify a token that is saved in a repo/org secret.
+The default GITHUB_TOKEN cannot trigger PR workflows, so the generated pull request will not run any
+status checks. You can work around this by using `token` to specify a token that is saved in a
+repo/org secret.
 
 See [Triggering further workflow
 runs](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
       - [`branch-prefix`](#branch-prefix)
       - [`create-pull-request`](#create-pull-request)
       - [`version-rule` and `use-dev-suffix`](#version-rule-and-use-dev-suffix)
+      - [`token`](#token)
 
 ## `ni/python-actions/setup-python`
 
@@ -252,3 +253,13 @@ The defaults are `version-rule=patch` and `use-dev-suffix=true`, which have the 
 
 When you are ready to exit the "dev" phase, you should manually update the version number to the
 desired release version before creating a release in GitHub.
+
+#### `token`
+
+The default GITHUB_TOKEN cannot trigger PR workflows. You can work around this by using `token` to
+specify a token that is saved in a repo/org secret.
+
+See [Triggering further workflow
+runs](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs)
+in the `create-pull-request` action documentation for more info about this problem and other
+solutions to it.

--- a/update-project-version/action.yml
+++ b/update-project-version/action.yml
@@ -15,8 +15,8 @@ inputs:
   token:
     description: >
       GitHub token to use to create the pull request. The default GITHUB_TOKEN
-      cannot trigger PR workflows, so you can use this to specify a PAT that is
-      saved in a repo/org secret.
+      cannot trigger PR workflows (i.e., it will not run PR status checks). You
+      can use this input to specify a PAT that is saved in a repo/org secret.
     default: ${{ github.token }}
   version-rule:
     description: >

--- a/update-project-version/action.yml
+++ b/update-project-version/action.yml
@@ -12,6 +12,12 @@ inputs:
       Specifies whether to create a pull request. Set this to false to update
       the project version without creating a pull request.
     default: true
+  token:
+    description: >
+      GitHub token to use to create the pull request. The default GITHUB_TOKEN
+      cannot trigger PR workflows, so you can use this to specify a PAT that is
+      saved in a repo/org secret.
+    default: ${{ github.token }}
   version-rule:
     description: >
       Specifies the rule for how to update the version number, such as "major",
@@ -58,6 +64,7 @@ runs:
       branch: ${{ steps.set-vars.outputs.branch-name }}
       commit-message: "chore: Update project version - ${{ steps.set-vars.outputs.base-branch }}"
       title: "chore: Update project version - ${{ steps.set-vars.outputs.base-branch }}"
+      token: ${{ inputs.token }}
       # The workflow log currently points to the run, not the specific job
       # within that run. Linking to a specific job requires the numeric job id,
       # which is not available in the github context.


### PR DESCRIPTION
### What does this Pull Request accomplish?

Enable using a non-default GitHub token to create the pull request.

### Why should this Pull Request be merged?

Potential fix for #6 

### What testing has been done?

I tested it with `GH_REPO_TOKEN` but I don't think this token has the right permissions. It created a PR, but did not add any checks for workflows.
https://github.com/ni/nitypes-python/pull/93