### PR TITLE
Set expected-version to release.tag_name for release events.

### DIFF
--- a/check-project-version/action.yml
+++ b/check-project-version/action.yml
@@ -6,10 +6,10 @@ inputs:
     default: ${{ github.workspace }}
   expected-version:
     description: >
-      The expected version. By default, this is `github.ref_name`, which is the
-      tag for a `release` event. If the version has a leading 'v', it will be
-      stripped.
-    default: ${{ github.ref_name }}
+      The expected version. By default, this is `github.event.release.tag_name`
+      for release events and `github.ref_name` otherwise. If the version has a
+      leading 'v', it will be stripped.
+    default: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
 runs:
   using: composite
   steps:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Changes the default `expected-version` value so that release events use `github.event.release.tag_name` instead of `github.ref_name`. All non-release events will continue to use `ref_name`.

### Why should this Pull Request be merged?

[AB#3176680](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3176680)

### What testing has been done?

I created a fork of `nitypes-python` and tried publishing to testpypi using my updated action.
https://github.com/mjohanse-emr/nitypes-python/actions/runs/15974070397
The job failed, but build step that contains `check-project-version` succeeded. The job failure appears to be because I don't have publish permissions on this repo.

PR checks for this repo succeeded.
