### PR TITLE
github: Use shared Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,6 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "branchPrefix": "users/renovate/",
-  "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigestsToSemver"
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "local>ni/python-renovate-config:recommended"
+    ]
 }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Use shared Renovate config in https://github.com/ni/python-renovate-config

Switch back to `.json` file extension. The [Renovate docs](https://docs.renovatebot.com/configuration-options/) say

> Renovate supports JSONC for .json files and any config files without file extension (e.g. .renovaterc). We also recommend you prefer using JSONC within a .json file to using a .json5 file if you want to add comments.

### Why should this Pull Request be merged?

Single-source Renovate config for Python projects.

### What testing has been done?

Tested in https://github.com/bkeryan/nitypes-python