### PR TITLE
docs: Replace @v0.2 with @v0 and recommend pinning

### DIFF
--- a/analyze-project/README.md
+++ b/analyze-project/README.md
@@ -10,6 +10,10 @@ This action requires Poetry, so you must call `ni/python-actions/setup-python` a
 
 ## Usage
 
+> **Note**
+> These examples use `@v0`, but pinning to a commit hash or full release tag is recommended for
+> build reproducibility and security.
+
 ```yaml
 steps:
 - uses: ni/python-actions/setup-python@v0

--- a/check-project-version/README.md
+++ b/check-project-version/README.md
@@ -12,11 +12,15 @@ This action requires Poetry, so you must call `ni/python-actions/setup-python` a
 
 ## Usage
 
+> **Note**
+> These examples use `@v0`, but pinning to a commit hash or full release tag is recommended for
+> build reproducibility and security.
+
 ```yaml
 steps:
-- uses: ni/python-actions/setup-python@v0.2
-- uses: ni/python-actions/setup-poetry@v0.2
-- uses: ni/python-actions/check-project-version@v0.2
+- uses: ni/python-actions/setup-python@v0
+- uses: ni/python-actions/setup-poetry@v0
+- uses: ni/python-actions/check-project-version@v0
   if: github.event_name == 'release'
 ```
 
@@ -27,7 +31,7 @@ steps:
 You can specify `project-directory` to check a project located in a subdirectory.
 
 ```yaml
-- uses: ni/python-actions/check-project-version@v0.2
+- uses: ni/python-actions/check-project-version@v0
   with:
     project-directory: packages/foo
 ```
@@ -37,7 +41,7 @@ You can specify `project-directory` to check a project located in a subdirectory
 You can specify `expected-version` to check against something other than `github.ref_name`.
 
 ```yaml
-- uses: ni/python-actions/check-project-version@v0.2
+- uses: ni/python-actions/check-project-version@v0
   with:
     expected-version: ${{ steps.get-expected-version.outputs.version }}
 ```

--- a/setup-poetry/README.md
+++ b/setup-poetry/README.md
@@ -10,10 +10,14 @@ By default, this action installs Poetry 2.1.4.
 
 ## Usage
 
+> **Note**
+> These examples use `@v0`, but pinning to a commit hash or full release tag is recommended for
+> build reproducibility and security.
+
 ```yaml
 steps:
-- uses: ni/python-actions/setup-python@v0.2
-- uses: ni/python-actions/setup-poetry@v0.2
+- uses: ni/python-actions/setup-python@v0
+- uses: ni/python-actions/setup-poetry@v0
 - run: poetry install -v
 ```
 
@@ -23,8 +27,8 @@ steps:
 
 ```yaml
 steps:
-- uses: ni/python-actions/setup-python@v0.2
-- uses: ni/python-actions/setup-poetry@v0.2
+- uses: ni/python-actions/setup-python@v0
+- uses: ni/python-actions/setup-poetry@v0
   with:
     poetry-version: 2.1.4
 - run: poetry install -v

--- a/setup-python/README.md
+++ b/setup-python/README.md
@@ -9,9 +9,13 @@ By default, this action installs Python 3.11.9.
 
 ## Usage
 
+> **Note**
+> These examples use `@v0`, but pinning to a commit hash or full release tag is recommended for
+> build reproducibility and security.
+
 ```yaml
 steps:
-- uses: ni/python-actions/setup-python@v0.2
+- uses: ni/python-actions/setup-python@v0
 ```
 
 ## Inputs
@@ -25,7 +29,7 @@ strategy:
   matrix:
     python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
 steps:
-- uses: ni/python-actions/setup-python@v0.2
+- uses: ni/python-actions/setup-python@v0
   with:
     python-version: ${{ matrix.python-version }}
 ```
@@ -38,7 +42,7 @@ You can use the `python-version` output to get the actual version of Python, whi
 
 ```yaml
 steps:
-- uses: ni/python-actions/setup-python@v0.2
+- uses: ni/python-actions/setup-python@v0
   id: setup-python
 - uses: actions/cache@v4
   with:
@@ -61,7 +65,7 @@ You can also use the `python-path` output to get the path to the Python interpre
 
 ```yaml
 steps:
-- uses: ni/python-actions/setup-python@v0.2
+- uses: ni/python-actions/setup-python@v0
   id: setup-python
 - run: pipx install <package> --python ${{ steps.setup-python.outputs.python-version }}
 ```

--- a/update-project-version/README.md
+++ b/update-project-version/README.md
@@ -18,11 +18,15 @@ permissions:
 
 ## Usage
 
+> **Note**
+> These examples use `@v0`, but pinning to a commit hash or full release tag is recommended for
+> build reproducibility and security.
+
 ```yaml
 steps:
-- uses: ni/python-actions/setup-python@v0.2
-- uses: ni/python-actions/setup-poetry@v0.2
-- uses: ni/python-actions/update-project-version@v0.2
+- uses: ni/python-actions/setup-python@v0
+- uses: ni/python-actions/setup-poetry@v0
+- uses: ni/python-actions/update-project-version@v0
 ```
 
 ## Inputs
@@ -32,7 +36,7 @@ steps:
 You can specify `project-directory` to update a project located in a subdirectory.
 
 ```yaml
-- uses: ni/python-actions/update-project-version@v0.2
+- uses: ni/python-actions/update-project-version@v0
   with:
     project-directory: packages/foo
 ```
@@ -44,7 +48,7 @@ You can specify `branch-prefix` to customize the pull request branch names. The 
 `users/build/update-project-version-releases-1.1`.
 
 ```yaml
-- uses: ni/python-actions/update-project-version@v0.2
+- uses: ni/python-actions/update-project-version@v0
   with:
     branch-prefix: users/python-build/
 ```
@@ -55,15 +59,15 @@ You can use `create-pull-request` and `project-directory` to update multiple pro
 pull request.
 
 ```yaml
-- uses: ni/python-actions/update-project-version@v0.2
+- uses: ni/python-actions/update-project-version@v0
   with:
     project-directory: packages/foo
     create-pull-request: false
-- uses: ni/python-actions/update-project-version@v0.2
+- uses: ni/python-actions/update-project-version@v0
   with:
     project-directory: packages/bar
     create-pull-request: false
-- uses: ni/python-actions/update-project-version@v0.2
+- uses: ni/python-actions/update-project-version@v0
   with:
     project-directory: packages/baz
     create-pull-request: true


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update the docs to use `@v0`, with a note recommending pinning to a commit hash or full release tag.

### Why should this Pull Request be merged?

`@v0.2` is outdated and should not be used.

### What testing has been done?

PR build