### PR TITLE
Use temporary directory for Poetry installs

### DIFF
--- a/setup-poetry/action.yml
+++ b/setup-poetry/action.yml
@@ -29,6 +29,7 @@ runs:
         poetry_root="$RUNNER_TEMP/poetry"
         poetry_home="$poetry_root/home"
         poetry_bin="$poetry_root/bin"
+        poetry_config="$poetry_root/config"
         if [[ "$RUNNER_OS" == "Windows" ]]; then
           binary_folder_name="Scripts"
         else
@@ -36,7 +37,7 @@ runs:
         fi
 
         echo "POETRY_BIN_DIR=$poetry_bin" >> "$GITHUB_ENV"
-        echo "POETRY_CONFIG_DIR=$poetry_root/config" >> "$GITHUB_ENV"
+        echo "POETRY_CONFIG_DIR=$poetry_config" >> "$GITHUB_ENV"
         echo "POETRY_HOME=$poetry_home" >> "$GITHUB_ENV"
         echo "POETRY_HOME_BIN=$poetry_home/$binary_folder_name" >> "$GITHUB_ENV"
         echo "$poetry_bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Changes in #34 cause self-hosted agents to run into issues, as the directory is not cleaned by GitHub Runner between runs.

Early versions of #26 proposed to use the temporary runner directory that is cleaned by the runner between runs, but due to concerns about caching and uncertainty about the order of operations during cleanup, it has been changed to the repository directory, which has its own set of issues, such as #33.

To resolve the issue, I've revisited the original approach:
- Caching has been previously implemented to support non-uniform temporary paths.
- Verified caching occurs before cleanup, as post steps (such as [caching](https://github.com/actions/cache/blob/0057852bfaa89a56745cba8c7296529d2fc39830/action.yml#L43C1-L43C29)) are synchronously run before final cleanup.

### Why should this Pull Request be merged?

- Fixes caching on self-hosted runners.
- Merge environment setup steps into one to reduce duplication.

### What testing has been done?

- Run on Linux containers twice [with success](https://github.com/ni/nibcq-python/actions/runs/18125033711/job/51578224448), verified caching works.
- Run on self-hosted Windows runner twice [with success](https://github.com/ni/nibcq-python/actions/runs/18125033711/job/51578271510).