### PR TITLE
setup-python: Remove custom python-version output logic

### DIFF
--- a/.github/workflows/test_actions.yml
+++ b/.github/workflows/test_actions.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
+        id: setup-python
         uses: ./setup-python
         with:
           python-version: ${{ matrix.python-version }}
@@ -25,7 +26,7 @@ jobs:
           import sys, sysconfig, re, os
 
           matrix_python_version = "${{ matrix.python-version }}"
-          env_python_version = os.environ["pythonVersion"]
+          output_python_version = "${{ steps.setup-python.outputs.python-version }}"
 
           match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", matrix_python_version)
           expected_version = tuple(int(g) for g in match.groups() if g is not None)
@@ -33,10 +34,10 @@ jobs:
           if version != expected_version:
               print(f"::error title=Test Failure::The Python version does not match. Got {version}, expected {expected_version}.")
               sys.exit(1)
-          match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", env_python_version)
-          env_version = tuple(int(g) for g in match.groups() if g is not None)[:len(expected_version)]
-          if env_version != expected_version:
-              print(f"::error title=Test Failure::The env.pythonVersion version does not match. Got {env_version}, expected {expected_version}.")
+          match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", output_python_version)
+          output_version = tuple(int(g) for g in match.groups() if g is not None)[:len(expected_version)]
+          if output_version != expected_version:
+              print(f"::error title=Test Failure::The outputs.python-version version does not match. Got {output_version}, expected {expected_version}.")
               sys.exit(1)
 
           implementation = sys.implementation.name
@@ -44,18 +45,23 @@ jobs:
           if implementation != expected_implementation:
               print(f"::error title=Test Failure::The Python implementation does not match. Got {implementation}, expected {expected_implementation}.")
               sys.exit(1)
-          env_implementation = "pypy" if env_python_version.startswith("pypy") else "cpython"
-          if env_implementation != expected_implementation:
-              print(f"::error title=Test Failure::The env.pythonVersion implementation does not match. Got {env_implementation}, expected {expected_implementation}.")
+          output_implementation = "pypy" if output_python_version.startswith("pypy") else "cpython"
+          if output_implementation != expected_implementation:
+              print(f"::error title=Test Failure::The outputs.python-version implementation does not match. Got {output_implementation}, expected {expected_implementation}.")
 
           threading = "free-threading" if sysconfig.get_config_var("Py_GIL_DISABLED") else "GIL"
           expected_threading = "free-threading" if "t" in matrix_python_version else "GIL"
           if threading != expected_threading:
               print(f"::error title=Test Failure::The Python threading does not match. Got {threading}, expected {expected_threading}.")
               sys.exit(1)
-          env_threading = "free-threading" if "t" in env_python_version else "GIL"
-          if env_threading != expected_threading:
-              print(f"::error title=Test Failure::The env.pythonVersion threading does not match. Got {env_threading}, expected {expected_threading}.")
+          output_threading = "free-threading" if "t" in output_python_version else "GIL"
+          if output_threading != expected_threading:
+              print(f"::error title=Test Failure::The outputs.python-version threading does not match. Got {output_threading}, expected {expected_threading}.")
+
+          env_python_version = os.environ["pythonVersion"]
+          if env_python_version != output_python_version:
+              print(f"::error title=Test Failure::env.pythonVersion does not match outputs.python-version. Got {env_python_version}, expected {output_python_version}.")
+              sys.exit(1)
         shell: python
 
   test_setup_poetry:

--- a/.github/workflows/test_actions.yml
+++ b/.github/workflows/test_actions.yml
@@ -22,23 +22,40 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Check Python version
         run: |
-          import sys, sysconfig, re
-          match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", "${{ matrix.python-version }}")
+          import sys, sysconfig, re, os
+
+          matrix_python_version = "${{ matrix.python-version }}"
+          env_python_version = os.environ["pythonVersion"]
+
+          match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", matrix_python_version)
           expected_version = tuple(int(g) for g in match.groups() if g is not None)
           version = sys.version_info[:len(expected_version)]
           if version != expected_version:
               print(f"::error title=Test Failure::The Python version does not match. Got {version}, expected {expected_version}.")
               sys.exit(1)
+          match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", env_python_version)
+          env_version = tuple(int(g) for g in match.groups() if g is not None)[:len(expected_version)]
+          if env_version != expected_version:
+              print(f"::error title=Test Failure::The env.pythonVersion version does not match. Got {env_version}, expected {expected_version}.")
+              sys.exit(1)
+
           implementation = sys.implementation.name
-          expected_implementation = "pypy" if "${{ matrix.python-version }}".startswith("pypy") else "cpython"
+          expected_implementation = "pypy" if matrix_python_version.startswith("pypy") else "cpython"
           if implementation != expected_implementation:
               print(f"::error title=Test Failure::The Python implementation does not match. Got {implementation}, expected {expected_implementation}.")
               sys.exit(1)
+          env_implementation = "pypy" if env_python_version.startswith("pypy") else "cpython"
+          if env_implementation != expected_implementation:
+              print(f"::error title=Test Failure::The env.pythonVersion implementation does not match. Got {env_implementation}, expected {expected_implementation}.")
+
           threading = "free-threading" if sysconfig.get_config_var("Py_GIL_DISABLED") else "GIL"
-          expected_threading = "free-threading" if "t" in "${{ matrix.python-version }}" else "GIL"
+          expected_threading = "free-threading" if "t" in matrix_python_version else "GIL"
           if threading != expected_threading:
               print(f"::error title=Test Failure::The Python threading does not match. Got {threading}, expected {expected_threading}.")
               sys.exit(1)
+          env_threading = "free-threading" if "t" in env_python_version else "GIL"
+          if env_threading != expected_threading:
+              print(f"::error title=Test Failure::The env.pythonVersion threading does not match. Got {env_threading}, expected {expected_threading}.")
         shell: python
 
   test_setup_poetry:

--- a/setup-python/action.yml
+++ b/setup-python/action.yml
@@ -7,7 +7,7 @@ outputs:
   python-path:
     value: ${{ steps.setup-python.outputs.python-path }}
   python-version:
-    value: ${{ steps.get-python-version.outputs.python-version }}
+    value: ${{ steps.setup-python.outputs.python-version }}
 runs:
   using: composite
   steps:
@@ -16,22 +16,6 @@ runs:
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
-    # Workaround for https://github.com/actions/setup-python/issues/1109 -
-    # Python-version output for PyPy isn't unique across different versions 
-    - name: Get Python version
-      id: get-python-version
-      run: |
-        import os, platform, sys, sysconfig
-        if sys.implementation.name == "pypy":
-            version = f"pypy{platform.python_version()}-v{'.'.join(map(str,sys.implementation.version[:3]))}"
-        else:
-            version = platform.python_version()
-        # Also take free-threading into account
-        if sysconfig.get_config_var("Py_GIL_DISABLED"):
-            version += "t"
-        with open(os.environ["GITHUB_OUTPUT"], "a") as output:
-            print(f"python-version={version}", file=output)
-      shell: python
     - name: Add pythonVersion environment variable
-      run: echo "pythonVersion=${{ steps.get-python-version.outputs.python-version }}" >> "$GITHUB_ENV"
+      run: echo "pythonVersion=${{ steps.setup-python.outputs.python-version }}" >> "$GITHUB_ENV"
       shell: bash


### PR DESCRIPTION
### What does this Pull Request accomplish?

Remove custom code for detecting the installed Python version and setting `outputs.python-version`. The standard `actions/setup-python` action's `outputs.python-version` now reports PyPy as `pypy3.11.13-7.3.20` and freethreading as `3.14.5t` like we expect, so we no longer need custom code for this.

Add test coverage for `env.pythonVersion` and `outputs.python-version`.

### Why should this Pull Request be merged?

Simplify action code, improve test coverage.

### What testing has been done?

PR build