### PR TITLE
setup-poetry, analyze-project: Work around actions/cache failures

### DIFF
--- a/analyze-project/README.md
+++ b/analyze-project/README.md
@@ -52,3 +52,7 @@ For example,
     project-directory: ${{ github.workspace }}/packages/myproject
     install-args: "--extras 'colors serialization' --with dev,docs,utils"
 ```
+
+### `use-cache`
+
+If you run into caching problems, you can disable caching by specifying `use-cache: false`.

--- a/analyze-project/action.yml
+++ b/analyze-project/action.yml
@@ -57,6 +57,8 @@ runs:
         INSTALL_ARGS: ${{ inputs.install-args }}
     - name: Cache virtualenv
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      # Work around https://github.com/actions/cache/issues/1754 - Windows runner randomly dies in actions/cache
+      continue-on-error: true
       with:
         path: ${{ steps.get_project_info.outputs.venv-path }}
         key: ${{ steps.get_project_info.outputs.name }}-${{ runner.os }}-py${{ env.pythonVersion }}-${{ hashFiles(format('{0}/poetry.lock', inputs.project-directory)) }}-${{ steps.install_args_hash.outputs.hash }}

--- a/analyze-project/action.yml
+++ b/analyze-project/action.yml
@@ -17,6 +17,11 @@ inputs:
     default: ''
     required: false
     type: string
+  use-cache:
+    description: >
+      A Boolean specifying whether to use the cache. Set this to false to work
+      around caching problems.
+    default: true
 
 runs:
   using: composite
@@ -56,6 +61,7 @@ runs:
       env:
         INSTALL_ARGS: ${{ inputs.install-args }}
     - name: Cache virtualenv
+      if: ${{ inputs.use-cache == 'true' }}
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       # Work around https://github.com/actions/cache/issues/1754 - Windows runner randomly dies in actions/cache
       continue-on-error: true

--- a/setup-poetry/action.yml
+++ b/setup-poetry/action.yml
@@ -53,6 +53,8 @@ runs:
       if: ${{ inputs.use-cache == 'true' }}
       id: cache-poetry
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      # Work around https://github.com/actions/cache/issues/1754 - Windows runner randomly dies in actions/cache
+      continue-on-error: true
       with:
         # Using ${{ env.POETRY_HOME }} here does not work because it is evaluated before the "set paths" step runs.
         path: |


### PR DESCRIPTION
### What does this Pull Request accomplish?

setup-poetry, analyze-project: Ignore errors from `actions/cache`

analyze-project: Add a `use-cache` input to allow clients to disable caching

### Why should this Pull Request be merged?

Work around https://github.com/actions/cache/issues/1754

### What testing has been done?

PR build