### PR TITLE
github: Update sync_github_issues_to_azdo.yml to use case function instead of shell script

### DIFF
--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -15,16 +15,6 @@ jobs:
     if: ${{ !github.event.issue.pull_request && github.event.issue.title != 'Dependency Dashboard' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Choose work item type
-        id: choose_work_item_type
-        run: |
-          if [ "${{ contains(github.event.issue.labels.*.name, 'enhancement') || contains(github.event.issue.labels.*.name, 'user story') }}" == "true" ]; then
-            echo "work_item_type=User Story" >> $GITHUB_OUTPUT
-          elif [ "${{ contains(github.event.issue.labels.*.name, 'tech debt') }}" == "true" ]; then
-            echo "work_item_type=Technical Debt" >> $GITHUB_OUTPUT
-          else
-            echo "work_item_type=Bug" >> $GITHUB_OUTPUT
-          fi
       - uses: danhellem/github-actions-issue-to-work-item@45eb3b46e684f2acd2954f02ef70350c835ee4bb # v2.4
         env:
           ado_token: "${{ secrets.AZDO_WORK_ITEM_TOKEN }}"
@@ -32,7 +22,10 @@ jobs:
           ado_organization: "ni"
           ado_project: "DevCentral"
           ado_area_path: "DevCentral\\Product RnD\\Platform HW and SW\\SW New Invest and Tech\\ETW\\Python CodeGen"
-          ado_wit: "${{ steps.choose_work_item_type.outputs.work_item_type }}"
+          ado_wit: "${{ case(
+            contains(github.event.issue.labels.*.name, 'enhancement') || contains(github.event.issue.labels.*.name, 'user story'), 'User Story',
+            contains(github.event.issue.labels.*.name, 'tech debt'), 'Technical Debt',
+            'Bug') }}"
           ado_new_state: "New"
           ado_active_state: "Active"
           ado_close_state: "Closed"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update sync_github_issues_to_azdo.yml to use the new-ish `case` function instead of a shell script.

### Why should this Pull Request be merged?

Clarify intent & improve readability

Avoid using bash in a workflow that may process untrusted user input (I think issue labels are under the repo's control, though)

### What testing has been done?

Made same change in other repos