### PR TITLE
setup-poetry: Update default Poetry version to 2.4.1

### DIFF
--- a/setup-poetry/README.md
+++ b/setup-poetry/README.md
@@ -6,7 +6,7 @@ speed up workflows.
 This action installs Poetry using the Python version that was selected by the
 `ni/python-actions/setup-python` action, so you must call `ni/python-actions/setup-python` first.
 
-By default, this action installs Poetry 2.1.4.
+By default, this action installs Poetry 2.4.1.
 
 ## Usage
 
@@ -30,7 +30,7 @@ steps:
 - uses: ni/python-actions/setup-python@v0
 - uses: ni/python-actions/setup-poetry@v0
   with:
-    poetry-version: 2.1.4
+    poetry-version: 2.4.1
 - run: poetry install -v
 ```
 

--- a/setup-poetry/action.yml
+++ b/setup-poetry/action.yml
@@ -2,7 +2,7 @@ name: Set up Poetry
 description: Install Poetry, add it to the PATH, and cache it to speed up workflows.
 inputs:
   poetry-version:
-    default: 2.1.4
+    default: 2.4.1
   use-cache:
     description: >
       A Boolean specifying whether to use the cache. Set this to false to work


### PR DESCRIPTION
### What does this Pull Request accomplish?

`setup-poetry`: Update the default value of `poetry-version` from 2.1.4 to 2.4.1

### Why should this Pull Request be merged?

Poetry 2.4 introduced the `solver.min-release-age` setting which makes Poetry work better with Renovate's `minimumReleaseAge` setting.

### What testing has been done?

PR build